### PR TITLE
カスタムヘルパーを追加した

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def full_title(page_title = '')
+    base_title = 'Ruby on Rails Tutorial Sample App'
+    page_title.empty? ? base_title : "#{page_title} | #{base_title}"
+  end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,7 +1,7 @@
 doctype html
 html
   head
-    title #{yield(:title)} | Ruby on Rails Tutorial Sample App
+    title #{full_title(yield(:title))}
     meta name="viewport" content="width=device-width,initial-scale=1"
     = csrf_meta_tags
     = csp_meta_tag

--- a/app/views/static_pages/home.html.slim
+++ b/app/views/static_pages/home.html.slim
@@ -1,4 +1,3 @@
-- provide(:title, 'Home')
 h1 Sample App
 p
   | This is the home page for the

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -10,13 +10,13 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
   test 'should get root' do
     get root_url
     assert_response :success
-    assert_select 'title', "Home | #{@base_title}"
+    assert_select 'title', 'Ruby on Rails Tutorial Sample App'
   end
 
   test 'should get home' do
     get static_pages_home_url
     assert_response :success
-    assert_select 'title', "Home | #{@base_title}"
+    assert_select 'title', 'Ruby on Rails Tutorial Sample App'
   end
 
   test 'should get help' do


### PR DESCRIPTION
## Issue
- #5 


## 概要
カスタムヘルパーを追加し、静的なページの`title`タグの文言表示を修正した。

また、ルートページとホームページ(`/`, `/static_pages/home`)では、ベースとなる文言のみを表示するようにした。


## 変更前
- ルートページ

<img width="591" alt="Home___Ruby_on_Rails_Tutorial_Sample_App_🔊" src="https://github.com/Kassy0220/sample_app/assets/79003082/bef42990-69d7-481c-9832-5c7dacf3d7b8">

- ホームページ

<img width="590" alt="Home___Ruby_on_Rails_Tutorial_Sample_App_🔊" src="https://github.com/Kassy0220/sample_app/assets/79003082/a121d96f-8293-4c93-afb0-3dd8cec0b6cb">

## 変更後
- ルートページ

<img width="589" alt="Ruby_on_Rails_Tutorial_Sample_App_🔊" src="https://github.com/Kassy0220/sample_app/assets/79003082/f271d644-db2c-437a-9871-d1fd4fd821e7">

- ホームページ

<img width="589" alt="Ruby_on_Rails_Tutorial_Sample_App_🔊" src="https://github.com/Kassy0220/sample_app/assets/79003082/eaaa0165-5d92-4547-bd6e-93924cef3751">


