### PR TITLE
ユーザー登録ページの追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,4 @@
+class UsersController < ApplicationController
+  def new
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/views/static_pages/home.html.slim
+++ b/app/views/static_pages/home.html.slim
@@ -9,7 +9,7 @@
     end
     |  sample application.
 
-  = link_to 'Sign up now!', '#', class: 'btn btn-lg btn-primary'
+  = link_to 'Sign up now!', signup_path, class: 'btn btn-lg btn-primary'
 
 = link_to image_tag('rails.svg', alt: 'Rails logo', width: '200'),
                     'https://rubyonrails.org/'

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -1,0 +1,6 @@
+- provide(:title, 'Sign up')
+h1
+  | Sign up
+
+p
+  | This will be a signup page for new users.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   get '/help', to: 'static_pages#help'
   get '/about', to: 'static_pages#about'
   get '/contact', to: 'static_pages#contact'
+  get '/signup', to: 'users#new'
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get signup_path
+    assert_response :success
+  end
+end

--- a/test/integration/site_layout_test.rb
+++ b/test/integration/site_layout_test.rb
@@ -10,8 +10,12 @@ class SiteLayoutTest < ActionDispatch::IntegrationTest
     assert_select 'a[href=?]', help_path
     assert_select 'a[href=?]', about_path
     assert_select 'a[href=?]', contact_path
+    assert_select 'a[href=?]', signup_path
 
     get contact_path
     assert_select 'title', full_title('Contact')
+
+    get signup_path
+    assert_select 'title', full_title('Sign up')
   end
 end


### PR DESCRIPTION
## Issue
- #9 

## 概要
ユーザー登録ページ(`/signup`)を作成し、ホーム画面からユーザー登録ページに遷移できる様にしました。