### PR TITLE
ユーザー登録をできるようにした

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -153,3 +153,18 @@ input, textarea, select, .uneditable-input {
 input {
   height: auto !important;
 }
+
+#error_explanation {
+  color: red;
+  ul {
+    color: red;
+    margin: 0 0 30px 0;
+  }
+}
+
+.field_with_errors {
+  @extend .has-error;
+  .form-control {
+    color: $state-danger-text;
+  }
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -96,3 +96,40 @@ footer {
     }
   }
 }
+
+/* sidebar */
+
+aside {
+  section.user_info {
+    margin-top: 20px;
+  }
+  section {
+    padding: 10px 0;
+    margin-top: 20px;
+    &:first-child {
+      border: 0;
+      padding-top: 0;
+    }
+    span {
+      display: block;
+      margin-bottom: 3px;
+      line-height: 1;
+    }
+    h1 {
+      font-size: 1.4em;
+      text-align: left;
+      letter-spacing: -1px;
+      margin-bottom: 3px;
+      margin-top: 0px;
+    }
+  }
+}
+
+.gravatar {
+  float: left;
+  margin-right: 10px;
+}
+
+.gravatar_edit {
+  margin-top: 15px;
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -4,6 +4,13 @@
 /* mixins, variables, etc. */
 
 $gray-medium-light: #eaeaea;
+$gray-medium-light: #eaeaea;
+
+@mixin box_sizing {
+  -moz-box-sizing:    border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing:         border-box;
+}
 
 /* universal */
 
@@ -132,4 +139,17 @@ aside {
 
 .gravatar_edit {
   margin-top: 15px;
+}
+
+/* forms */
+
+input, textarea, select, .uneditable-input {
+  border: 1px solid #bbb;
+  width: 100%;
+  margin-bottom: 15px;
+  @include box_sizing;
+}
+
+input {
+  height: auto !important;
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
+  def show
+    @user = User.find(params[:id])
+  end
+
   def new; end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,5 +5,7 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
   end
 
-  def new; end
+  def new
+    @user = User.new
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,4 +8,19 @@ class UsersController < ApplicationController
   def new
     @user = User.new
   end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      # 保存成功時の処理
+    else
+      render 'new', status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,8 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      # 保存成功時の処理
+      flash[:success] = 'Welcome to the Sample App!'
+      redirect_to @user
     else
       render 'new', status: :unprocessable_entity
     end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module UsersHelper
+  def gravatar_for(user)
+    gravatar_id = Digest::MD5.hexdigest(user.email.downcase)
+    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}"
+    image_tag(gravatar_url, alt: user.name, class: 'gravatar')
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module UsersHelper
-  def gravatar_for(user)
+  def gravatar_for(user, size: 80)
     gravatar_id = Digest::MD5.hexdigest(user.email.downcase)
-    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}"
+    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
     image_tag(gravatar_url, alt: user.name, class: 'gravatar')
   end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -13,5 +13,7 @@ html
   body
     = render 'layouts/header'
     .container
+      - flash.each do |message_type, message|
+        = tag.div message, class: %W[alert alert-#{message_type}]
       = yield
       = render 'layouts/footer'

--- a/app/views/shared/_error_messages.html.slim
+++ b/app/views/shared/_error_messages.html.slim
@@ -1,0 +1,10 @@
+- if @user.errors.any?
+  #error_explanation
+    .alert.alert-danger
+      | The form contains
+      = pluralize(@user.errors.count, 'error')
+      | .
+    ul
+      - @user.errors.full_messages.each do |msg|
+        li
+          = msg

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -2,5 +2,19 @@
 h1
   | Sign up
 
-p
-  | This will be a signup page for new users.
+.row
+  .col-md-6.col-md-offset-3
+    = form_with(model: @user) do |f|
+      = f.label :name
+      = f.text_field :name
+
+      = f.label :email
+      = f.email_field :email
+
+      = f.label :password
+      = f.password_field :password
+
+      = f.label :password_confirmation, 'Confirmation'
+      = f.password_field :password_confirmation
+
+      = f.submit 'Create my account', class: 'btn btn-primary'

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -5,16 +5,18 @@ h1
 .row
   .col-md-6.col-md-offset-3
     = form_with(model: @user) do |f|
+      = render 'shared/error_messages'
+
       = f.label :name
-      = f.text_field :name
+      = f.text_field :name, class: 'form-control'
 
       = f.label :email
-      = f.email_field :email
+      = f.email_field :email, class: 'form-control'
 
       = f.label :password
-      = f.password_field :password
+      = f.password_field :password, class: 'form-control'
 
       = f.label :password_confirmation, 'Confirmation'
-      = f.password_field :password_confirmation
+      = f.password_field :password_confirmation, class: 'form-control'
 
       = f.submit 'Create my account', class: 'btn btn-primary'

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,4 +1,8 @@
-p
-  => @user.name
-  | ,
-  =< @user.email
+- provide(:title, @user.name)
+
+.row
+  aside.col-md-4
+    section.user_info
+      h1
+        = gravatar_for @user
+        = @user.email

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,0 +1,4 @@
+p
+  => @user.name
+  | ,
+  =< @user.email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   get '/about', to: 'static_pages#about'
   get '/contact', to: 'static_pages#contact'
   get '/signup', to: 'users#new'
+  resources :users
 end

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UsersSignupTest < ActionDispatch::IntegrationTest
+  test 'invalid singup information' do
+    get signup_path
+    assert_no_difference 'User.count' do
+      post users_path, params: { user: { name: '',
+                                         email: 'user@invalid',
+                                         password: 'test',
+                                         password_confirmation: 'te' } }
+    end
+    assert_response :unprocessable_entity
+    assert_template 'users/new'
+    assert_select 'li', "Name can't be blank"
+    assert_select 'li', 'Email is invalid'
+    assert_select 'li', "Password confirmation doesn't match Password"
+    assert_select 'li', 'Password is too short (minimum is 8 characters)'
+  end
+end

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -18,4 +18,16 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     assert_select 'li', "Password confirmation doesn't match Password"
     assert_select 'li', 'Password is too short (minimum is 8 characters)'
   end
+
+  test 'valid signup information' do
+    assert_difference 'User.count', 1 do
+      post users_path, params: { user: { name: 'Example User',
+                                         email: 'user@example.com',
+                                         password: 'testtest',
+                                         password_confirmation: 'testtest' } }
+    end
+    follow_redirect!
+    assert_template 'users/show'
+    assert_select '.alert-success', 'Welcome to the Sample App!'
+  end
 end


### PR DESCRIPTION
## Issue
- #13 

## 概要
ユーザー登録フォーム(`/signup`)を追加し、ユーザー登録をできるようにしました。
ユーザー登録が完了すると、登録したユーザーの詳細ページに遷移します。

※ 7.5以降扱われている本番環境の設定は、当PRには含まれていません

## スクリーンショット

[![Image from Gyazo](https://i.gyazo.com/62232461b5536fdec64baf81804409e8.gif)](https://gyazo.com/62232461b5536fdec64baf81804409e8)
