### PR TITLE
落ちているテストを修正した

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,7 +15,7 @@ ja:
         name: 名前
         email: メールアドレス
         password: パスワード
-        password_digest: パスワード(確認)
+        password_confirmation: パスワード(確認)
   date:
     abbr_day_names:
     - 日

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -13,10 +13,10 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     end
     assert_response :unprocessable_entity
     assert_template 'users/new'
-    assert_select 'li', "Name can't be blank"
-    assert_select 'li', 'Email is invalid'
-    assert_select 'li', "Password confirmation doesn't match Password"
-    assert_select 'li', 'Password is too short (minimum is 8 characters)'
+    assert_select 'li', '名前を入力してください'
+    assert_select 'li', 'メールアドレスは不正な値です'
+    assert_select 'li', 'パスワード(確認)とパスワードの入力が一致しません'
+    assert_select 'li', 'パスワードは8文字以上で入力してください'
   end
 
   test 'valid signup information' do
@@ -28,6 +28,6 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     end
     follow_redirect!
     assert_template 'users/show'
-    assert_select '.alert-success', 'Welcome to the Sample App!'
+    assert_select '.alert-success', 'Sample App へようこそ！'
   end
 end


### PR DESCRIPTION
## 概要
- #18 

上記のPRで一部のメッセージが日本語表示に変更されたことに伴い、一部のテストが落ちるようになっていた問題を修正しました。

また、`User`モデルの翻訳で属性名が誤っている箇所があったので、そちらも修正しています。