### PR TITLE
ユーザー登録フォームの、ラベルの文言を修正

### DIFF
--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -16,7 +16,7 @@ h1
       = f.label :password
       = f.password_field :password, class: 'form-control'
 
-      = f.label :password_confirmation, 'Confirmation'
+      = f.label :password_confirmation
       = f.password_field :password_confirmation, class: 'form-control'
 
       = f.submit 'Create my account', class: 'btn btn-primary'


### PR DESCRIPTION
## 概要

ユーザー登録フォームのラベルの文章が一部英語になっていたため、`ja.yml`で設定した訳語が表示されるように修正しました。

## スクショ
### 変更前
<img width="506" alt="Sign_up___Ruby_on_Rails_Tutorial_Sample_App_🔊" src="https://github.com/Kassy0220/sample_app/assets/79003082/70cfdd5a-a012-4f88-891e-2e5a2ef770ee">


### 変更後

<img width="553" alt="Sign_up___Ruby_on_Rails_Tutorial_Sample_App_🔊" src="https://github.com/Kassy0220/sample_app/assets/79003082/7f369baa-393b-4fb5-8dc4-8d5239a77b9a">

